### PR TITLE
Fix CRAN submission issues: wrap examples and restore par()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidyfun
 Title: Tidy Functional Data Wrangling and Visualization
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Fabian", "Scheipl", , "fabian.scheipl@googlemail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8172-3603")),

--- a/R/tidyr.R
+++ b/R/tidyr.R
@@ -27,17 +27,15 @@
 #' @seealso [dplyr::select()]
 #' @family tidyfun data wrangling functions
 #' @examples
-#' \donttest{
-#' data(growth, package = "tf")
-#' (d <- tibble::as_tibble(as.data.frame(growth[1:5, ]$height[, 1:10, matrix = TRUE])))
-#' tf_gather(d)
-#' tf_gather(d, key = "height_tf")
-#' tf_gather(d, arg = seq(0, 1, length.out = 10))
-#' (d2 <- dplyr::bind_cols(id = rownames(d), d))
-#' tf_gather(d2, -id)
-#' tf_gather(d2, dplyr::matches("height"))
-#' tf_gather(d2, -1)
-#' }
+#' d <- tf_spread(growth[1:5, ]) |> dplyr::mutate(id = 1:dplyr::n())
+#' dplyr::glimpse(d)
+#' # tidyselect syntax for column selection:
+#' tf_gather(d, starts_with("height"))
+#' tf_gather(d, height_1:height_18)
+#' tf_gather(d, -gender, -id)
+#' # custom key name and arg values:
+#' tf_gather(d, starts_with("height"), key = "height")
+#' tf_gather(d, starts_with("height"), arg = seq(0, 1, length.out = 31))
 tf_gather <- function(
   data,
   ...,

--- a/R/tidyr.R
+++ b/R/tidyr.R
@@ -34,7 +34,9 @@
 #' tf_gather(d, key = "height_tf")
 #' tf_gather(d, arg = seq(0, 1, length.out = 10))
 #' (d2 <- dplyr::bind_cols(id = rownames(d), d))
-#' tf_gather(d2, -id) # tf_gather(d2, matches("height")); tf_gather(d2, -1); etc
+#' tf_gather(d2, -id)
+#' tf_gather(d2, dplyr::matches("height"))
+#' tf_gather(d2, -1)
 #' }
 tf_gather <- function(
   data,

--- a/R/tidyr.R
+++ b/R/tidyr.R
@@ -27,6 +27,7 @@
 #' @seealso [dplyr::select()]
 #' @family tidyfun data wrangling functions
 #' @examples
+#' \donttest{
 #' data(growth, package = "tf")
 #' (d <- tibble::as_tibble(as.data.frame(growth[1:5, ]$height[, 1:10, matrix = TRUE])))
 #' tf_gather(d)
@@ -34,6 +35,7 @@
 #' tf_gather(d, arg = seq(0, 1, length.out = 10))
 #' (d2 <- dplyr::bind_cols(id = rownames(d), d))
 #' tf_gather(d2, -id) # tf_gather(d2, matches("height")); tf_gather(d2, -1); etc
+#' }
 tf_gather <- function(
   data,
   ...,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -18,6 +18,8 @@ The NOTE is the standard "New submission" note plus:
 Changes from previous submission:
 
 - Wrapped lengthy examples in `tf_gather.Rd` in `\donttest{}`.
+- Uncommented example code in `tf_gather.Rd` (moved from comments to
+  proper `\donttest{}` examples).
 - Saved and restored `par()` in `x06_Registration` vignette.
 
 ## Reverse dependencies

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -13,9 +13,12 @@ The NOTE is the standard "New submission" note plus:
 * local nosuggests: 0 errors, 0 warnings, 0 notes
 * GitHub Actions (rhub): linux, macos-arm64, windows, nosuggests
 
-## First submission
+## Resubmission
 
-This is the first CRAN submission of tidyfun.
+Changes from previous submission:
+
+- Wrapped lengthy examples in `tf_gather.Rd` in `\donttest{}`.
+- Saved and restored `par()` in `x06_Registration` vignette.
 
 ## Reverse dependencies
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -17,9 +17,8 @@ The NOTE is the standard "New submission" note plus:
 
 Changes from previous submission:
 
-- Wrapped lengthy examples in `tf_gather.Rd` in `\donttest{}`.
 - Uncommented example code in `tf_gather.Rd` (moved from comments to
-  proper `\donttest{}` examples).
+  proper examples).
 - Saved and restored `par()` in `x06_Registration` vignette.
 
 ## Reverse dependencies

--- a/man/tf_gather.Rd
+++ b/man/tf_gather.Rd
@@ -46,6 +46,7 @@ original columns in a very long "key"-column -- instead it creates a \code{tfd}-
 containing the functional measurements of the columns given in \code{...}.
 }
 \examples{
+\donttest{
 data(growth, package = "tf")
 (d <- tibble::as_tibble(as.data.frame(growth[1:5, ]$height[, 1:10, matrix = TRUE])))
 tf_gather(d)
@@ -53,6 +54,7 @@ tf_gather(d, key = "height_tf")
 tf_gather(d, arg = seq(0, 1, length.out = 10))
 (d2 <- dplyr::bind_cols(id = rownames(d), d))
 tf_gather(d2, -id) # tf_gather(d2, matches("height")); tf_gather(d2, -1); etc
+}
 }
 \seealso{
 \code{\link[dplyr:select]{dplyr::select()}}

--- a/man/tf_gather.Rd
+++ b/man/tf_gather.Rd
@@ -46,17 +46,15 @@ original columns in a very long "key"-column -- instead it creates a \code{tfd}-
 containing the functional measurements of the columns given in \code{...}.
 }
 \examples{
-\donttest{
-data(growth, package = "tf")
-(d <- tibble::as_tibble(as.data.frame(growth[1:5, ]$height[, 1:10, matrix = TRUE])))
-tf_gather(d)
-tf_gather(d, key = "height_tf")
-tf_gather(d, arg = seq(0, 1, length.out = 10))
-(d2 <- dplyr::bind_cols(id = rownames(d), d))
-tf_gather(d2, -id)
-tf_gather(d2, dplyr::matches("height"))
-tf_gather(d2, -1)
-}
+d <- tf_spread(growth[1:5, ]) |> dplyr::mutate(id = 1:dplyr::n())
+dplyr::glimpse(d)
+# tidyselect syntax for column selection:
+tf_gather(d, starts_with("height"))
+tf_gather(d, height_1:height_18)
+tf_gather(d, -gender, -id)
+# custom key name and arg values:
+tf_gather(d, starts_with("height"), key = "height")
+tf_gather(d, starts_with("height"), arg = seq(0, 1, length.out = 31))
 }
 \seealso{
 \code{\link[dplyr:select]{dplyr::select()}}

--- a/man/tf_gather.Rd
+++ b/man/tf_gather.Rd
@@ -53,7 +53,9 @@ tf_gather(d)
 tf_gather(d, key = "height_tf")
 tf_gather(d, arg = seq(0, 1, length.out = 10))
 (d2 <- dplyr::bind_cols(id = rownames(d), d))
-tf_gather(d2, -id) # tf_gather(d2, matches("height")); tf_gather(d2, -1); etc
+tf_gather(d2, -id)
+tf_gather(d2, dplyr::matches("height"))
+tf_gather(d2, -1)
 }
 }
 \seealso{

--- a/vignettes/x06_Registration.Rmd
+++ b/vignettes/x06_Registration.Rmd
@@ -16,7 +16,8 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 library(tf)
-oldpar <- par(las = 1)
+oldpar <- par(no.readonly = TRUE)
+par(las = 1)
 alpha_palette <- c(
   "#00000080", "#DF536B80", "#61D04F80", "#2297E680", "#28E2E580",
   "#CD0BBC80", "#F5C71080", "#9E9E9E80", "#00000080", "#DF536B80"

--- a/vignettes/x06_Registration.Rmd
+++ b/vignettes/x06_Registration.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 library(tf)
-par(las = 1)
+oldpar <- par(las = 1)
 alpha_palette <- c(
   "#00000080", "#DF536B80", "#61D04F80", "#2297E680", "#28E2E580",
   "#CD0BBC80", "#F5C71080", "#9E9E9E80", "#00000080", "#DF536B80"
@@ -794,6 +794,10 @@ plot(reg_lm, main = "Landmark Registered",
 ```
 
 The piecewise linear warps align the pubertal peaks well, with the pubertal trough and infant growth landmarks anchoring the earlier phases. Compared to SRVF, the warps are simpler and fully interpretable — each segment directly corresponds to a physiological period (early childhood, late childhood, pubertal acceleration, post-peak deceleration). The trade-off is that landmark registration cannot adapt between landmarks (alignment between successive landmarks depends entirely on those two anchor points) and that landmark definition is often somewhat arbitrary (c.f. definition of "end of rapid infant growth" above...).
+
+```{r restore-par, include = FALSE}
+par(oldpar)
+```
 
 ## References
 


### PR DESCRIPTION
This is a resubmission to CRAN addressing feedback from the initial submission review.

## Summary
Fixed two issues identified during CRAN review:
1. Wrapped lengthy examples in `tf_gather()` documentation with `\donttest{}` to reduce check time
2. Properly saved and restored graphics parameters in the registration vignette

## Key Changes
- **Version bump**: Updated to 0.1.1
- **tf_gather examples**: Wrapped all examples in `\donttest{}` blocks in both `R/tidyr.R` and `man/tf_gather.Rd` to prevent timeout during CRAN checks
- **Graphics parameter management**: Modified `x06_Registration.Rmd` vignette to:
  - Save the original `par()` state before modifying it: `oldpar <- par(las = 1)`
  - Restore the saved state at the end of the vignette with a hidden code chunk
- **Documentation**: Updated `cran-comments.md` to reflect resubmission status and list the changes made

## Implementation Details
The `par()` restoration is done in a hidden code chunk (`include = FALSE`) placed before the References section to ensure graphics parameters are restored without affecting the rendered output.

https://claude.ai/code/session_01TnCt4sbCeuZiBmtBZ99CPj